### PR TITLE
Assume that unaligned access is not allowed unless we know otherwise

### DIFF
--- a/SDL_net.h
+++ b/SDL_net.h
@@ -430,9 +430,9 @@ SDL_FORCE_INLINE void _SDLNet_Write32(Uint32 value, void *areap)
     area[3] =  value        & 0xFF;
 }
 
-SDL_FORCE_INLINE Uint16 _SDLNet_Read16(void *areap)
+SDL_FORCE_INLINE Uint16 _SDLNet_Read16(const void *areap)
 {
-    Uint8 *area = (Uint8*)areap;
+    const Uint8 *area = (const Uint8*)areap;
     return ((Uint16)area[0]) << 8 | ((Uint16)area[1]);
 }
 

--- a/SDL_net.h
+++ b/SDL_net.h
@@ -374,12 +374,12 @@ extern DECLSPEC const char * SDLCALL SDLNet_GetError(void);
 /* Inline functions to read/write network data                         */
 /***********************************************************************/
 
-/* Warning, some systems have data access alignment restrictions */
-#if defined(sparc) || defined(mips) || defined(__arm__)
-#define SDL_DATA_ALIGNED    1
+/* Warning, most systems have data access alignment restrictions */
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86) || defined(_M_AMD64)
+#define SDL_DATA_ALIGNED    0
 #endif
 #ifndef SDL_DATA_ALIGNED
-#define SDL_DATA_ALIGNED    0
+#define SDL_DATA_ALIGNED    1
 #endif
 
 /* Write a 16/32-bit value to network packet buffer */

--- a/SDLnet.c
+++ b/SDLnet.c
@@ -270,7 +270,7 @@ int SDLNet_GetLocalAddresses(IPaddress *addresses, int maxcount)
     return count;
 }
 
-#if !defined(WITHOUT_SDL) && !SDL_DATA_ALIGNED /* function versions for binary compatibility */
+/* function versions for binary compatibility */
 
 #undef SDLNet_Write16
 #undef SDLNet_Write32
@@ -282,27 +282,25 @@ extern DECLSPEC void SDLCALL SDLNet_Write16(Uint16 value, void *area);
 extern DECLSPEC void SDLCALL SDLNet_Write32(Uint32 value, void *area);
 
 /* Read a 16/32 bit value from network packet buffer */
-extern DECLSPEC Uint16 SDLCALL SDLNet_Read16(void *area);
+extern DECLSPEC Uint16 SDLCALL SDLNet_Read16(const void *area);
 extern DECLSPEC Uint32 SDLCALL SDLNet_Read32(const void *area);
 
 void  SDLNet_Write16(Uint16 value, void *areap)
 {
-    (*(Uint16 *)(areap) = SDL_SwapBE16(value));
+    _SDLNet_Write16(value, areap);
 }
 
 void   SDLNet_Write32(Uint32 value, void *areap)
 {
-    *(Uint32 *)(areap) = SDL_SwapBE32(value);
+    _SDLNet_Write32(value, areap);
 }
 
-Uint16 SDLNet_Read16(void *areap)
+Uint16 SDLNet_Read16(const void *areap)
 {
-    return (SDL_SwapBE16(*(Uint16 *)(areap)));
+    return _SDLNet_Read16(areap);
 }
 
 Uint32 SDLNet_Read32(const void *areap)
 {
-    return (SDL_SwapBE32(*(Uint32 *)(areap)));
+    return _SDLNet_Read32(areap);
 }
-
-#endif /* !defined(WITHOUT_SDL) && !SDL_DATA_ALIGNED */


### PR DESCRIPTION
* _SDLNet_Read16: Be const-correct in unaligned code path
    
    We only read from areap here, we don't write to it.

* Always implement exported symbols for SDLNet_Write16 etc.
    
    It's easier to reason about the ABI if the same set of symbols is
    exported on all architectures, and always exporting these avoids
    breaking ABI when another architecture is found to require alignment.
    
    Regardless of whether we are performing unaligned access or not, we can
    implement the extern versions in terms of the inline versions.

* Assume that unaligned access is not allowed unless we know otherwise
    
    x86 architecturally allows unaligned access, but this is unusual:
    other CPU architectures generally do not. The safe assumption is that
    unaligned access on an unknown CPU architecture will either be very
    slow, or not work at all.
    
    Instead of assuming that unknown architectures are like x86, let's
    assume they are like ARM. This is true for riscv64, for example[1].
    
    x86 is the outlier here, and is the most likely to be extensively tested
    by SDL_net maintainers, so specifically detect x86 (using the predefined
    macros from gcc, clang and MSVC) and continue to use unaligned accesses
    there.
    
    [1] https://wiki.debian.org/ArchitectureSpecificsMemo#Alignment