### PR TITLE
[WINCE] Fix detection of WINDRES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,12 +51,7 @@ AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-if test -z "$host_alias"; then
-    hostaliaswindres=
-else
-    hostaliaswindres="$host_alias-windres"
-fi
-AC_CHECK_PROGS(WINDRES, [windres $hostaliaswindres $host_os-windres])
+AC_CHECK_TOOL(WINDRES, [windres], [:])
 
 case "$host" in
     *-*-beos*)


### PR DESCRIPTION
I tried to build with `arm-mingw32ce` cross compiler and I got this error:

```
arm-mingw32ce-gcc -shared  .libs/SDLnet.o .libs/SDLnetTCP.o .libs/SDLnetUDP.o .libs/SDLnetselect.o   -lws2 -liphlpapi /opt/cegcc/arm-mingw32ce/lib/libSDLmain.a /opt/cegcc/arm-mingw32ce/lib/libSDL.dll.a -lmmtimer -lcoredll -lcommctrl version.o   -o .libs/SDL_net.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libSDL_net.dll.a
version.o: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
```

This happened because `version.o` has been compiled with the WINDRES provided by CYGWIN instead of using `arm-mingw32ce-windres`.
I would like to suggest to import the same code used by SDL-1.2 for detecting WINDRES.
By applying this fix, the problem has been solved.
Tested with:
* x86_64-pc-cygwin
* x86_64-w64-mingw32
* i686-w64-mingw32
* arm-mingw32ce

Perhaps, if you think that it is a good fix, it would be worth to import it also in the main branch.