### PR TITLE
Fix build on Xcode.

### DIFF
--- a/Xcode/SDL_net.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_net.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 					"$(HOME)/Library/Frameworks/SDL.framework/Headers",
 					/Library/Frameworks/SDL.framework/Headers,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = SDL2_net;
 				SDKROOT = macosx;
@@ -486,7 +486,7 @@
 					"$(HOME)/Library/Frameworks/SDL.framework/Headers",
 					/Library/Frameworks/SDL.framework/Headers,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = SDL2_net;
 				SDKROOT = macosx;
 				SEPARATE_STRIP = YES;


### PR DESCRIPTION
This PR bumps MACOSX_DEPLOYMENT_TARGET up to 10.6 (was 10.5) in order to meet SDL2's minimum (defined in `SDL2/SDL_platform.h:107`).