### PR TITLE
Bump up minimum macOS version to 10.7.

### DIFF
--- a/Xcode/SDL_net.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_net.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 					"$(HOME)/Library/Frameworks/SDL.framework/Headers",
 					/Library/Frameworks/SDL.framework/Headers,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = SDL2_net;
 				SDKROOT = macosx;
@@ -486,7 +486,7 @@
 					"$(HOME)/Library/Frameworks/SDL.framework/Headers",
 					/Library/Frameworks/SDL.framework/Headers,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = SDL2_net;
 				SDKROOT = macosx;
 				SEPARATE_STRIP = YES;


### PR DESCRIPTION
Similar to libsdl-org/SDL_net#46, since  https://github.com/libsdl-org/SDL/commit/d35c737f1c8ba4d28c3d45c557961b3ddce9bef0 the minimum macOS version is 10.7, SDL_net's minimum must be the same in order to compile the Xcode project with the latest SDL2.