### PR TITLE
autoconf: use ax_compute_relative_paths

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -95,7 +95,11 @@ host_triplet = @host@
 @ENABLE_EXAMPLES_TRUE@noinst_PROGRAMS = $(am__EXEEXT_1)
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/acinclude/libtool.m4 \
+am__aclocal_m4_deps =  \
+	$(top_srcdir)/acinclude/ax_compute_relative_paths.m4 \
+	$(top_srcdir)/acinclude/ax_normalize_path.m4 \
+	$(top_srcdir)/acinclude/ax_recursive_eval.m4 \
+	$(top_srcdir)/acinclude/libtool.m4 \
 	$(top_srcdir)/acinclude/ltoptions.m4 \
 	$(top_srcdir)/acinclude/ltsugar.m4 \
 	$(top_srcdir)/acinclude/ltversion.m4 \

--- a/acinclude/ax_compute_relative_paths.m4
+++ b/acinclude/ax_compute_relative_paths.m4
@@ -1,0 +1,173 @@
+# ==============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_compute_relative_paths.html
+# ==============================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPUTE_RELATIVE_PATHS(PATH_LIST)
+#
+# DESCRIPTION
+#
+#   PATH_LIST is a space-separated list of colon-separated triplets of the
+#   form 'FROM:TO:RESULT'. This function iterates over these triplets and
+#   set $RESULT to the relative path from $FROM to $TO. Note that $FROM and
+#   $TO needs to be absolute filenames for this macro to success.
+#
+#   For instance,
+#
+#     first=/usr/local/bin
+#     second=/usr/local/share
+#     AX_COMPUTE_RELATIVE_PATHS([first:second:fs second:first:sf])
+#     # $fs is set to ../share
+#     # $sf is set to ../bin
+#
+#   $FROM and $TO are both eval'ed recursively and normalized, this means
+#   that you can call this macro with autoconf's dirnames like `prefix' or
+#   `datadir'. For example:
+#
+#     AX_COMPUTE_RELATIVE_PATHS([bindir:datadir:bin_to_data])
+#
+#   AX_COMPUTE_RELATIVE_PATHS should also works with DOS filenames.
+#
+#   You may want to use this macro in order to make your package
+#   relocatable. Instead of hardcoding $datadir into your programs just
+#   encode $bin_to_data and try to determine $bindir at run-time.
+#
+#   This macro requires AX_NORMALIZE_PATH and AX_RECURSIVE_EVAL.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Alexandre Duret-Lutz <adl@gnu.org>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 12
+
+AU_ALIAS([ADL_COMPUTE_RELATIVE_PATHS], [AX_COMPUTE_RELATIVE_PATHS])
+AC_DEFUN([AX_COMPUTE_RELATIVE_PATHS],
+[for _lcl_i in $1; do
+  _lcl_from=\[$]`echo "[$]_lcl_i" | sed 's,:.*$,,'`
+  _lcl_to=\[$]`echo "[$]_lcl_i" | sed 's,^[[^:]]*:,,' | sed 's,:[[^:]]*$,,'`
+  _lcl_result_var=`echo "[$]_lcl_i" | sed 's,^.*:,,'`
+  AX_RECURSIVE_EVAL([[$]_lcl_from], [_lcl_from])
+  AX_RECURSIVE_EVAL([[$]_lcl_to], [_lcl_to])
+  _lcl_notation="$_lcl_from$_lcl_to"
+  AX_NORMALIZE_PATH([_lcl_from],['/'])
+  AX_NORMALIZE_PATH([_lcl_to],['/'])
+  AX_COMPUTE_RELATIVE_PATH([_lcl_from], [_lcl_to], [_lcl_result_tmp])
+  AX_NORMALIZE_PATH([_lcl_result_tmp],["[$]_lcl_notation"])
+  eval $_lcl_result_var='[$]_lcl_result_tmp'
+done])
+
+## Note:
+## *****
+## The following helper macros are too fragile to be used out
+## of AX_COMPUTE_RELATIVE_PATHS (mainly because they assume that
+## paths are normalized), that's why I'm keeping them in the same file.
+## Still, some of them maybe worth to reuse.
+
+dnl AX_COMPUTE_RELATIVE_PATH(FROM, TO, RESULT)
+dnl ===========================================
+dnl Compute the relative path to go from $FROM to $TO and set the value
+dnl of $RESULT to that value.  This function work on raw filenames
+dnl (for instead it will considerate /usr//local and /usr/local as
+dnl two distinct paths), you should really use AX_COMPUTE_RELATIVE_PATHS
+dnl instead to have the paths sanitized automatically.
+dnl
+dnl For instance:
+dnl    first_dir=/somewhere/on/my/disk/bin
+dnl    second_dir=/somewhere/on/another/disk/share
+dnl    AX_COMPUTE_RELATIVE_PATH(first_dir, second_dir, first_to_second)
+dnl will set $first_to_second to '../../../another/disk/share'.
+AC_DEFUN([AX_COMPUTE_RELATIVE_PATH],
+[AX_COMPUTE_COMMON_PATH([$1], [$2], [_lcl_common_prefix])
+AX_COMPUTE_BACK_PATH([$1], [_lcl_common_prefix], [_lcl_first_rel])
+AX_COMPUTE_SUFFIX_PATH([$2], [_lcl_common_prefix], [_lcl_second_suffix])
+$3="[$]_lcl_first_rel[$]_lcl_second_suffix"])
+
+dnl AX_COMPUTE_COMMON_PATH(LEFT, RIGHT, RESULT)
+dnl ============================================
+dnl Compute the common path to $LEFT and $RIGHT and set the result to $RESULT.
+dnl
+dnl For instance:
+dnl    first_path=/somewhere/on/my/disk/bin
+dnl    second_path=/somewhere/on/another/disk/share
+dnl    AX_COMPUTE_COMMON_PATH(first_path, second_path, common_path)
+dnl will set $common_path to '/somewhere/on'.
+AC_DEFUN([AX_COMPUTE_COMMON_PATH],
+[$3=''
+_lcl_second_prefix_match=''
+while test "[$]_lcl_second_prefix_match" != 0; do
+  _lcl_first_prefix=`expr "x[$]$1" : "x\([$]$3/*[[^/]]*\)"`
+  _lcl_second_prefix_match=`expr "x[$]$2" : "x[$]_lcl_first_prefix"`
+  if test "[$]_lcl_second_prefix_match" != 0; then
+    if test "[$]_lcl_first_prefix" != "[$]$3"; then
+      $3="[$]_lcl_first_prefix"
+    else
+      _lcl_second_prefix_match=0
+    fi
+  fi
+done])
+
+dnl AX_COMPUTE_SUFFIX_PATH(PATH, SUBPATH, RESULT)
+dnl ==============================================
+dnl Subtract $SUBPATH from $PATH, and set the resulting suffix
+dnl (or the empty string if $SUBPATH is not a subpath of $PATH)
+dnl to $RESULT.
+dnl
+dnl For instance:
+dnl    first_path=/somewhere/on/my/disk/bin
+dnl    second_path=/somewhere/on
+dnl    AX_COMPUTE_SUFFIX_PATH(first_path, second_path, common_path)
+dnl will set $common_path to '/my/disk/bin'.
+AC_DEFUN([AX_COMPUTE_SUFFIX_PATH],
+[$3=`expr "x[$]$1" : "x[$]$2/*\(.*\)"`])
+
+dnl AX_COMPUTE_BACK_PATH(PATH, SUBPATH, RESULT)
+dnl ============================================
+dnl Compute the relative path to go from $PATH to $SUBPATH, knowing that
+dnl $SUBPATH is a subpath of $PATH (any other words, only repeated '../'
+dnl should be needed to move from $PATH to $SUBPATH) and set the value
+dnl of $RESULT to that value.  If $SUBPATH is not a subpath of PATH,
+dnl set $RESULT to the empty string.
+dnl
+dnl For instance:
+dnl    first_path=/somewhere/on/my/disk/bin
+dnl    second_path=/somewhere/on
+dnl    AX_COMPUTE_BACK_PATH(first_path, second_path, back_path)
+dnl will set $back_path to '../../../'.
+AC_DEFUN([AX_COMPUTE_BACK_PATH],
+[AX_COMPUTE_SUFFIX_PATH([$1], [$2], [_lcl_first_suffix])
+$3=''
+_lcl_tmp='xxx'
+while test "[$]_lcl_tmp" != ''; do
+  _lcl_tmp=`expr "x[$]_lcl_first_suffix" : "x[[^/]]*/*\(.*\)"`
+  if test "[$]_lcl_first_suffix" != ''; then
+     _lcl_first_suffix="[$]_lcl_tmp"
+     $3="../[$]$3"
+  fi
+done])

--- a/acinclude/ax_normalize_path.m4
+++ b/acinclude/ax_normalize_path.m4
@@ -1,0 +1,115 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_normalize_path.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_NORMALIZE_PATH(VARNAME, [REFERENCE_STRING])
+#
+# DESCRIPTION
+#
+#   Perform some cleanups on the value of $VARNAME (interpreted as a path):
+#
+#     - empty paths are changed to '.'
+#     - trailing slashes are removed
+#     - repeated slashes are squeezed except a leading doubled slash '//'
+#       (which might indicate a networked disk on some OS).
+#
+#   REFERENCE_STRING is used to turn '/' into '\' and vice-versa: if
+#   REFERENCE_STRING contains some backslashes, all slashes and backslashes
+#   are turned into backslashes, otherwise they are all turned into slashes.
+#
+#   This makes processing of DOS filenames quite easier, because you can
+#   turn a filename to the Unix notation, make your processing, and turn it
+#   back to original notation.
+#
+#     filename='A:\FOO\\BAR\'
+#     old_filename="$filename"
+#     # Switch to the unix notation
+#     AX_NORMALIZE_PATH([filename], ["/"])
+#     # now we have $filename = 'A:/FOO/BAR' and we can process it as if
+#     # it was a Unix path.  For instance let's say that you want
+#     # to append '/subpath':
+#     filename="$filename/subpath"
+#     # finally switch back to the original notation
+#     AX_NORMALIZE_PATH([filename], ["$old_filename"])
+#     # now $filename equals to 'A:\FOO\BAR\subpath'
+#
+#   One good reason to make all path processing with the unix convention is
+#   that backslashes have a special meaning in many cases. For instance
+#
+#     expr 'A:\FOO' : 'A:\Foo'
+#
+#   will return 0 because the second argument is a regex in which
+#   backslashes have to be backslashed. In other words, to have the two
+#   strings to match you should write this instead:
+#
+#     expr 'A:\Foo' : 'A:\\Foo'
+#
+#   Such behavior makes DOS filenames extremely unpleasant to work with. So
+#   temporary turn your paths to the Unix notation, and revert them to the
+#   original notation after the processing. See the macro
+#   AX_COMPUTE_RELATIVE_PATHS for a concrete example of this.
+#
+#   REFERENCE_STRING defaults to $VARIABLE, this means that slashes will be
+#   converted to backslashes if $VARIABLE already contains some backslashes
+#   (see $thirddir below).
+#
+#     firstdir='/usr/local//share'
+#     seconddir='C:\Program Files\\'
+#     thirddir='C:\home/usr/'
+#     AX_NORMALIZE_PATH([firstdir])
+#     AX_NORMALIZE_PATH([seconddir])
+#     AX_NORMALIZE_PATH([thirddir])
+#     # $firstdir = '/usr/local/share'
+#     # $seconddir = 'C:\Program Files'
+#     # $thirddir = 'C:\home\usr'
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Alexandre Duret-Lutz <adl@gnu.org>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 8
+
+AU_ALIAS([ADL_NORMALIZE_PATH], [AX_NORMALIZE_PATH])
+AC_DEFUN([AX_NORMALIZE_PATH],
+[case ":[$]$1:" in
+# change empty paths to '.'
+  ::) $1='.' ;;
+# strip trailing slashes
+  :*[[\\/]]:) $1=`echo "[$]$1" | sed 's,[[\\/]]*[$],,'` ;;
+  :*:) ;;
+esac
+# squeeze repeated slashes
+case ifelse($2,,"[$]$1",$2) in
+# if the path contains any backslashes, turn slashes into backslashes
+ *\\*) $1=`echo "[$]$1" | sed 's,\(.\)[[\\/]][[\\/]]*,\1\\\\,g'` ;;
+# if the path contains slashes, also turn backslashes into slashes
+ *) $1=`echo "[$]$1" | sed 's,\(.\)[[\\/]][[\\/]]*,\1/,g'` ;;
+esac])

--- a/acinclude/ax_recursive_eval.m4
+++ b/acinclude/ax_recursive_eval.m4
@@ -1,0 +1,56 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_recursive_eval.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_RECURSIVE_EVAL(VALUE, RESULT)
+#
+# DESCRIPTION
+#
+#   Interpolate the VALUE in loop until it doesn't change, and set the
+#   result to $RESULT. WARNING: It's easy to get an infinite loop with some
+#   unsane input.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Alexandre Duret-Lutz <adl@gnu.org>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 1
+
+AC_DEFUN([AX_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1148,6 +1148,9 @@ AC_SUBST([am__tar])
 AC_SUBST([am__untar])
 ]) # _AM_PROG_TAR
 
+m4_include([acinclude/ax_compute_relative_paths.m4])
+m4_include([acinclude/ax_normalize_path.m4])
+m4_include([acinclude/ax_recursive_eval.m4])
 m4_include([acinclude/libtool.m4])
 m4_include([acinclude/ltoptions.m4])
 m4_include([acinclude/ltsugar.m4])

--- a/configure
+++ b/configure
@@ -13270,9 +13270,99 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 CFLAGS="$CFLAGS $SDL_CFLAGS"
 LIBS="$LIBS $SDL_LIBS"
 
-eval pkg_prefix=$prefix
-eval pkg_cmakedir=$libdir/cmake/SDL2_net
-cmake_prefix_relpath="$(echo -n "$pkg_cmakedir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g")"
+pkg_cmakedir='$libdir/cmake/SDL2_net'
+for _lcl_i in pkg_cmakedir:prefix:cmake_prefix_relpath; do
+  _lcl_from=\$`echo "$_lcl_i" | sed 's,:.*$,,'`
+  _lcl_to=\$`echo "$_lcl_i" | sed 's,^[^:]*:,,' | sed 's,:[^:]*$,,'`
+  _lcl_result_var=`echo "$_lcl_i" | sed 's,^.*:,,'`
+  _lcl_receval="$_lcl_from"
+_lcl_from=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "$_lcl_receval_old" != "$_lcl_receval"; do
+       _lcl_receval_old="$_lcl_receval"
+       eval _lcl_receval="\"$_lcl_receval\""
+     done
+     echo "$_lcl_receval")`
+  _lcl_receval="$_lcl_to"
+_lcl_to=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "$_lcl_receval_old" != "$_lcl_receval"; do
+       _lcl_receval_old="$_lcl_receval"
+       eval _lcl_receval="\"$_lcl_receval\""
+     done
+     echo "$_lcl_receval")`
+  _lcl_notation="$_lcl_from$_lcl_to"
+  case ":$_lcl_from:" in
+# change empty paths to '.'
+  ::) _lcl_from='.' ;;
+# strip trailing slashes
+  :*[\\/]:) _lcl_from=`echo "$_lcl_from" | sed 's,[\\/]*$,,'` ;;
+  :*:) ;;
+esac
+# squeeze repeated slashes
+case '/' in
+# if the path contains any backslashes, turn slashes into backslashes
+ *\\*) _lcl_from=`echo "$_lcl_from" | sed 's,\(.\)[\\/][\\/]*,\1\\\\,g'` ;;
+# if the path contains slashes, also turn backslashes into slashes
+ *) _lcl_from=`echo "$_lcl_from" | sed 's,\(.\)[\\/][\\/]*,\1/,g'` ;;
+esac
+  case ":$_lcl_to:" in
+# change empty paths to '.'
+  ::) _lcl_to='.' ;;
+# strip trailing slashes
+  :*[\\/]:) _lcl_to=`echo "$_lcl_to" | sed 's,[\\/]*$,,'` ;;
+  :*:) ;;
+esac
+# squeeze repeated slashes
+case '/' in
+# if the path contains any backslashes, turn slashes into backslashes
+ *\\*) _lcl_to=`echo "$_lcl_to" | sed 's,\(.\)[\\/][\\/]*,\1\\\\,g'` ;;
+# if the path contains slashes, also turn backslashes into slashes
+ *) _lcl_to=`echo "$_lcl_to" | sed 's,\(.\)[\\/][\\/]*,\1/,g'` ;;
+esac
+  _lcl_common_prefix=''
+_lcl_second_prefix_match=''
+while test "$_lcl_second_prefix_match" != 0; do
+  _lcl_first_prefix=`expr "x$_lcl_from" : "x\($_lcl_common_prefix/*[^/]*\)"`
+  _lcl_second_prefix_match=`expr "x$_lcl_to" : "x$_lcl_first_prefix"`
+  if test "$_lcl_second_prefix_match" != 0; then
+    if test "$_lcl_first_prefix" != "$_lcl_common_prefix"; then
+      _lcl_common_prefix="$_lcl_first_prefix"
+    else
+      _lcl_second_prefix_match=0
+    fi
+  fi
+done
+_lcl_first_suffix=`expr "x$_lcl_from" : "x$_lcl_common_prefix/*\(.*\)"`
+_lcl_first_rel=''
+_lcl_tmp='xxx'
+while test "$_lcl_tmp" != ''; do
+  _lcl_tmp=`expr "x$_lcl_first_suffix" : "x[^/]*/*\(.*\)"`
+  if test "$_lcl_first_suffix" != ''; then
+     _lcl_first_suffix="$_lcl_tmp"
+     _lcl_first_rel="../$_lcl_first_rel"
+  fi
+done
+_lcl_second_suffix=`expr "x$_lcl_to" : "x$_lcl_common_prefix/*\(.*\)"`
+_lcl_result_tmp="$_lcl_first_rel$_lcl_second_suffix"
+  case ":$_lcl_result_tmp:" in
+# change empty paths to '.'
+  ::) _lcl_result_tmp='.' ;;
+# strip trailing slashes
+  :*[\\/]:) _lcl_result_tmp=`echo "$_lcl_result_tmp" | sed 's,[\\/]*$,,'` ;;
+  :*:) ;;
+esac
+# squeeze repeated slashes
+case "$_lcl_notation" in
+# if the path contains any backslashes, turn slashes into backslashes
+ *\\*) _lcl_result_tmp=`echo "$_lcl_result_tmp" | sed 's,\(.\)[\\/][\\/]*,\1\\\\,g'` ;;
+# if the path contains slashes, also turn backslashes into slashes
+ *) _lcl_result_tmp=`echo "$_lcl_result_tmp" | sed 's,\(.\)[\\/][\\/]*,\1/,g'` ;;
+esac
+  eval $_lcl_result_var='$_lcl_result_tmp'
+done
 
 
 CheckWarnAll

--- a/configure.ac
+++ b/configure.ac
@@ -200,9 +200,8 @@ CFLAGS="$CFLAGS $SDL_CFLAGS"
 LIBS="$LIBS $SDL_LIBS"
 
 dnl Calculate the location of the prefix, relative to the cmake folder
-eval pkg_prefix=$prefix
-eval pkg_cmakedir=$libdir/cmake/SDL2_net
-cmake_prefix_relpath="$(echo -n "$pkg_cmakedir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g")"
+pkg_cmakedir='$libdir/cmake/SDL2_net'
+AX_COMPUTE_RELATIVE_PATHS([pkg_cmakedir:prefix:cmake_prefix_relpath])
 AC_SUBST([cmake_prefix_relpath])
 
 dnl check for GCC warning options

--- a/sdl2_net-config.cmake.in
+++ b/sdl2_net-config.cmake.in
@@ -8,7 +8,7 @@ set_package_properties(SDL2_net PROPERTIES
 
 set(SDL2_net_FOUND TRUE)
 
-get_filename_component(prefix "${CMAKE_CURRENT_LIST_DIR}@cmake_prefix_relpath@" ABSOLUTE)
+get_filename_component(prefix "${CMAKE_CURRENT_LIST_DIR}/@cmake_prefix_relpath@" ABSOLUTE)
 set(exec_prefix "@exec_prefix@")
 set(bindir "@bindir@")
 set(includedir "@includedir@")


### PR DESCRIPTION
SDL_net equivalent of https://github.com/libsdl-org/SDL/pull/5955, https://github.com/libsdl-org/SDL_ttf/pull/238, https://github.com/libsdl-org/SDL_image/pull/295 and https://github.com/libsdl-org/SDL_mixer/pull/432

This allows absolute paths for e.g. `--libdir` when using autotools' `configure` script.