### PR TITLE
Always install SDL2_net.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,39 +202,46 @@ if(SDL2NET_INSTALL)
         COMPONENT devel
     )
 
-    if(SDL2NET_BUILD_SHARED_LIBS)
-        # Only create a .pc file for a shared SDL2_net
-        set(prefix "${CMAKE_INSTALL_PREFIX}")
-        set(exec_prefix "\${prefix}")
-        set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
-        set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-        set(PACKAGE "${PROJECT_NAME}")
-        set(VERSION "${FULL_VERSION}")
-        set(SDL_VERSION "${SDL_REQUIRED_VERSION}")
-        string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
-        string(JOIN " " PC_LIBS ${PC_LIBS})
-        configure_file("${PROJECT_SOURCE_DIR}/SDL2_net.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc.intermediate" @ONLY)
-        file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/SDL2_net-$<CONFIG>.pc" INPUT "${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc.intermediate")
-
-        set(PC_DESTDIR)
-        if(CMAKE_SYSTEM_NAME MATCHES FreeBSD)
-            # FreeBSD uses ${PREFIX}/libdata/pkgconfig
-            set(PC_DESTDIR "libdata/pkgconfig")
+        if(SDL2NET_BUILD_SHARED_LIBS)
+            set(ENABLE_SHARED_TRUE "")
+            set(ENABLE_SHARED_FALSE "#")
+            set(ENABLE_STATIC_TRUE "#")
+            set(ENABLE_STATIC_FALSE "")
         else()
-            set(PC_DESTDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+            set(ENABLE_SHARED_TRUE "#")
+            set(ENABLE_SHARED_FALSE "")
+            set(ENABLE_STATIC_TRUE "")
+            set(ENABLE_STATIC_FALSE "#")
         endif()
-        # Only install a SDL2_net.pc file in Release mode
-        install(CODE "
-            if(CMAKE_INSTALL_CONFIG_NAME MATCHES \"Release\")
-                # FIXME: use file(COPY_FILE) if minimum CMake version >= 3.21
-                execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E copy_if_different
-                    \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_net-$<CONFIG>.pc\"
-                    \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc\")
-                file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
-                    TYPE FILE
-                    FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc\")
-            endif()" COMPONENT devel)
+
+    set(prefix "${CMAKE_INSTALL_PREFIX}")
+    set(exec_prefix "\${prefix}")
+    set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PACKAGE "${PROJECT_NAME}")
+    set(VERSION "${FULL_VERSION}")
+    set(SDL_VERSION "${SDL_REQUIRED_VERSION}")
+    string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
+    string(JOIN " " PC_LIBS ${PC_LIBS})
+    configure_file("${PROJECT_SOURCE_DIR}/SDL2_net.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc.intermediate" @ONLY)
+    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/SDL2_net-$<CONFIG>.pc" INPUT "${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc.intermediate")
+
+    set(PC_DESTDIR)
+    if(CMAKE_SYSTEM_NAME MATCHES FreeBSD)
+        # FreeBSD uses ${PREFIX}/libdata/pkgconfig
+        set(PC_DESTDIR "libdata/pkgconfig")
+    else()
+        set(PC_DESTDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
     endif()
+    # Always install SDL2_net.pc: libraries might be different between config modes
+    install(CODE "
+        # FIXME: use file(COPY_FILE) if minimum CMake version >= 3.21
+        execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E copy_if_different
+            \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_net-$<CONFIG>.pc\"
+            \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc\")
+        file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
+            TYPE FILE
+            FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_net.pc\")" COMPONENT devel)
 
     if(SDL2NET_BUILD_SHARED_LIBS AND (APPLE OR (UNIX AND NOT ANDROID)))
         install(


### PR DESCRIPTION
- Always install `SDL2_net.pc`, independent of building a shared/static SDL2_net and independent of building a release/debug version.
  Fixes #60
- ~Test the version embedded in`./configure` in `./test-versioning.sh`.~