### PR TITLE
SDL_net for SDL 1.2 on the PSP.

### DIFF
--- a/Makefile.psp
+++ b/Makefile.psp
@@ -9,20 +9,10 @@ CFLAGS = -g -O2 -G0 -Wall -D__PSP__ -DHAVE_OPENGL $(shell $(PSPBIN)/sdl-config -
 CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
 ASFLAGS = $(CFLAGS)
 
-#Basic compiler stuff and paths
-PSPSDK = $(shell psp-config --pspsdk-path)
-PSPDEV = $(shell psp-config -d)
-PSPBIN = $(PSPDEV)/bin
-SDL_CONFIG = $(PSPBIN)/sdl-config
+PSPBIN = $(shell psp-config -d)/bin
 
-LDFLAGS=-L$(psp-config --pspsdk-path)/lib
+LDFLAGS=-L$(shell psp-config --pspsdk-path)/lib
 LIBS=-lc -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpsputility -lpspuser
-#-lpsphttp -lpspssl -lpspwlan \
-#-lpspnet_adhocmatching -lpspnet_adhoc -lpspnet_adhocctl -lm
-
-#LIBS = -lGL -lGLU -lglut -lz \
-#         -lpspvfpu -lpsphprm -lpspsdk -lpspctrl -lpspumd -lpsprtc -lpsppower -lpspgum -lpspgu -lpspaudiolib -lpspaudio -lpsphttp -lpspssl -lpspwlan \
-#         -lpspnet_adhocmatching -lpspnet_adhoc -lpspnet_adhocctl -lm -lpspvram
 
 install: $(TARGET_LIB)
 	cp $(TARGET_LIB) $(shell psp-config --psp-prefix)/lib

--- a/Makefile.psp
+++ b/Makefile.psp
@@ -1,0 +1,32 @@
+TARGET_LIB = libSDL_net.a
+OBJS= SDLnet.o \
+      SDLnetselect.o \
+      SDLnetTCP.o \
+      SDLnetUDP.o \
+
+INCDIR = .
+CFLAGS = -g -O2 -G0 -Wall -D__PSP__ -DHAVE_OPENGL $(shell $(PSPBIN)/sdl-config --cflags)
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+ASFLAGS = $(CFLAGS)
+
+#Basic compiler stuff and paths
+PSPSDK = $(shell psp-config --pspsdk-path)
+PSPDEV = $(shell psp-config -d)
+PSPBIN = $(PSPDEV)/bin
+SDL_CONFIG = $(PSPBIN)/sdl-config
+
+LDFLAGS=-L$(psp-config --pspsdk-path)/lib
+LIBS=-lc -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpsputility -lpspuser
+#-lpsphttp -lpspssl -lpspwlan \
+#-lpspnet_adhocmatching -lpspnet_adhoc -lpspnet_adhocctl -lm
+
+#LIBS = -lGL -lGLU -lglut -lz \
+#         -lpspvfpu -lpsphprm -lpspsdk -lpspctrl -lpspumd -lpsprtc -lpsppower -lpspgum -lpspgu -lpspaudiolib -lpspaudio -lpsphttp -lpspssl -lpspwlan \
+#         -lpspnet_adhocmatching -lpspnet_adhoc -lpspnet_adhocctl -lm -lpspvram
+
+install: $(TARGET_LIB)
+	cp $(TARGET_LIB) $(shell psp-config --psp-prefix)/lib
+	cp SDL_net.h $(shell psp-config --psp-prefix)/include
+
+PSPSDK=$(shell psp-config --pspsdk-path)
+include $(PSPSDK)/lib/build.mak

--- a/SDL_net.h
+++ b/SDL_net.h
@@ -35,13 +35,11 @@ extern "C" {
 #endif
 
 //The SDL_reinterpret_cast isn't defined before 1.2.14, so define it if required
-#if !SDL_VERSION_ATLEAST(1,2,14)
 #ifndef SDL_reinterpret_cast
 #ifdef __cplusplus
 #define SDL_reinterpret_cast(type, expression) reinterpret_cast<type>(expression)
 #else
 #define SDL_reinterpret_cast(type, expression) ((type)(expression))
-#endif
 #endif
 #endif
 

--- a/SDL_net.h
+++ b/SDL_net.h
@@ -34,6 +34,17 @@
 extern "C" {
 #endif
 
+//The SDL_reinterpret_cast isn't defined before 1.2.14, so define it if required
+#if !SDL_VERSION_ATLEAST(1,2,14)
+#ifndef SDL_reinterpret_cast
+#ifdef __cplusplus
+#define SDL_reinterpret_cast(type, expression) reinterpret_cast<type>(expression)
+#else
+#define SDL_reinterpret_cast(type, expression) ((type)(expression))
+#endif
+#endif
+#endif
+
 /* Printable format: "%d.%d.%d", MAJOR, MINOR, PATCHLEVEL
 */
 #define SDL_NET_MAJOR_VERSION	1

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -37,7 +37,7 @@
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
 #else /* UNIX */
-#ifdef __OS2__
+#if defined(__OS2__) || defined(__PSP__)
 #include <sys/param.h>
 #endif
 #include <sys/types.h>
@@ -49,18 +49,24 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
-#ifndef __BEOS__
+#if !defined(__BEOS__) || defined(__PSP__)
 #include <arpa/inet.h>
 #endif
 #ifdef __linux__ /* FIXME: what other platforms have this? */
 #include <netinet/tcp.h>
 #endif
 #include <sys/socket.h>
+#ifndef __PSP__
 #include <net/if.h>
+#endif
 #include <netdb.h>
 #endif /* WIN32 */
 
-#ifdef __OS2__
+#ifdef __PSP__
+#include <sys/select.h> //Required for the FD_SET etc.
+#endif
+
+#if defined(__OS2__)
 typedef int socklen_t;
 #elif 0
 /* FIXME: What platforms need this? */

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -49,7 +49,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
-#if !defined(__BEOS__) || defined(__PSP__)
+#ifndef __BEOS__
 #include <arpa/inet.h>
 #endif
 #ifdef __linux__ /* FIXME: what other platforms have this? */

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -66,7 +66,7 @@
 #include <sys/select.h> //Required for the FD_SET etc.
 #endif
 
-#if defined(__OS2__)
+#ifdef __OS2__
 typedef int socklen_t;
 #elif 0
 /* FIXME: What platforms need this? */


### PR DESCRIPTION
These are the changes I made to allow SDL_net to compile on the Minimalist PSPSDK 0.10.0

It's my first attempt at actually porting any library, but it looks fine as far as I can see (just a few header changes and missing Makefile due to autoconf not working on the devkit). It's working pretty much exactly like the other PSP ports of the libraries (SDL_gfx etc.).

Although I didn't test the actual functionality on a real PSP or emulated system (other than a quick test if it doesn't crash).
And of course platform-specific stuff like connecting to the WiFi network on the PSP is to be done by the app itself (as it has nothing to do with SDL_net directly, like on other operating systems).