### PR TITLE
SDL2_net for SDL2 on the PSP

### DIFF
--- a/Makefile.psp
+++ b/Makefile.psp
@@ -1,0 +1,22 @@
+TARGET_LIB = libSDL2_net.a
+OBJS= SDLnet.o \
+      SDLnetselect.o \
+      SDLnetTCP.o \
+      SDLnetUDP.o \
+
+INCDIR = .
+CFLAGS = -g -O2 -G0 -Wall -D__PSP__ $(shell $(PSPBIN)/sdl2-config --cflags)
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+ASFLAGS = $(CFLAGS)
+
+PSPBIN = $(shell psp-config -d)/bin
+
+LDFLAGS=-L$(shell psp-config --pspsdk-path)/lib
+LIBS=-lc -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpsputility -lpspuser
+
+install: $(TARGET_LIB)
+	cp $(TARGET_LIB) $(shell psp-config --psp-prefix)/lib
+	cp SDL_net.h $(shell psp-config --psp-prefix)/include
+
+PSPSDK=$(shell psp-config --pspsdk-path)
+include $(PSPSDK)/lib/build.mak

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -41,7 +41,7 @@
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
 #else /* UNIX */
-#ifdef __OS2__
+#if defined(__OS2__) || defined(__PSP__)
 #include <sys/param.h>
 #endif
 #include <sys/types.h>
@@ -58,9 +58,15 @@
 #endif
 #include <netinet/tcp.h>
 #include <sys/socket.h>
+#ifndef __PSP__
 #include <net/if.h>
+#endif
 #include <netdb.h>
 #endif /* WIN32 */
+
+#ifdef __PSP__
+#include <sys/select.h> /* for FD_SET, etc */
+#endif
 
 #ifdef __OS2__
 typedef int socklen_t;


### PR DESCRIPTION
As mentioned in https://github.com/libsdl-org/SDL_net/pull/64 , this time a SDL_net port for the SDL2_net library of the main branch. There's a few differences on the two branches, which are taken into account here (newer headers not in the 1.2 branch, as well as using SDL2 instead of SDL 1.2 (which affects the sdl-config becoming sdl2-config and the TARGET_LIB field to produce a SDL2_net library instead of a SDL_net library)).