### PR TITLE
Allow binding a TCP server to a specific interface

### DIFF
--- a/SDL_net.h
+++ b/SDL_net.h
@@ -208,6 +208,45 @@ extern DECLSPEC int SDLCALL SDLNet_GetLocalAddresses(IPaddress *addresses, int m
 typedef struct _TCPsocket *TCPsocket;
 
 /**
+ * Open a server TCP network socket.
+ *
+ * If `ip->host` is INADDR_NONE or INADDR_ANY, the socket is bound to
+ * all interfaces, otherwise it is bound to the specified interface.
+ * The address passed in should already be swapped to network byte order
+ * (addresses returned from SDLNet_ResolveHost() are already in the
+ * correct form).
+ *
+ * \param ip The address to host a server on.
+ * \returns the newly created socket, or NULL if there was an error.
+ *
+ * \since This function is available since SDL_net 2.0.0.
+ *
+ * \sa SDLNet_TCP_Close
+ * \sa SDLNet_TCP_OpenClient
+ * \sa SDLNet_TCP_Open
+ */
+extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenServer(IPaddress *ip);
+
+/**
+ * Open a client TCP network socket.
+ *
+ * Attempt a TCP connection to the remote host and port.
+ * The address passed in should already be swapped to network byte order
+ * (addresses returned from SDLNet_ResolveHost() are already in the
+ * correct form).
+ *
+ * \param ip The address to open a connection to.
+ * \returns the newly created socket, or NULL if there was an error.
+ *
+ * \since This function is available since SDL_net 2.0.0.
+ *
+ * \sa SDLNet_TCP_Close
+ * \sa SDLNet_TCP_OpenServer
+ * \sa SDLNet_TCP_Open
+ */
+extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenClient(IPaddress *ip);
+
+/**
  * Open a TCP network socket.
  *
  * If `ip->host` is INADDR_NONE or INADDR_ANY, this creates a local server
@@ -222,6 +261,8 @@ typedef struct _TCPsocket *TCPsocket;
  * \since This function is available since SDL_net 2.0.0.
  *
  * \sa SDLNet_TCP_Close
+ * \sa SDLNet_TCP_OpenServer
+ * \sa SDLNet_TCP_OpenClient
  */
 extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_Open(IPaddress *ip);
 

--- a/SDL_net.h
+++ b/SDL_net.h
@@ -238,7 +238,7 @@ extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenServer(IPaddress *ip);
  * \param ip The address to open a connection to.
  * \returns the newly created socket, or NULL if there was an error.
  *
- * \since This function is available since SDL_net 2.0.0.
+ * \since This function is available since SDL_net 2.4.0.
  *
  * \sa SDLNet_TCP_Close
  * \sa SDLNet_TCP_OpenServer

--- a/SDL_net.h
+++ b/SDL_net.h
@@ -219,7 +219,7 @@ typedef struct _TCPsocket *TCPsocket;
  * \param ip The address to host a server on.
  * \returns the newly created socket, or NULL if there was an error.
  *
- * \since This function is available since SDL_net 2.0.0.
+ * \since This function is available since SDL_net 2.4.0.
  *
  * \sa SDLNet_TCP_Close
  * \sa SDLNet_TCP_OpenClient

--- a/SDLnetTCP.c
+++ b/SDLnetTCP.c
@@ -42,7 +42,7 @@ struct _TCPsocket {
    and port is attempted.
    The newly created socket is returned, or NULL if there was an error.
 */
-static TCPsocket _SDLNet_TCP_Open(IPaddress *ip, int openAsClient)
+static TCPsocket SDLNet_TCP_OpenInternal(IPaddress *ip, int openAsClient)
 {
     TCPsocket sock;
     struct sockaddr_in sock_addr;
@@ -164,7 +164,7 @@ error_return:
 */
 TCPsocket SDLNet_TCP_OpenServer(IPaddress *ip)
 {
-    return _SDLNet_TCP_Open(ip, 0);
+    return SDLNet_TCP_OpenInternal(ip, 0);
 }
 
 /* Open a client TCP network socket.
@@ -173,7 +173,7 @@ TCPsocket SDLNet_TCP_OpenServer(IPaddress *ip)
 */
 TCPsocket SDLNet_TCP_OpenClient(IPaddress *ip)
 {
-    return _SDLNet_TCP_Open(ip, 1);
+    return SDLNet_TCP_OpenInternal(ip, 1);
 }
 
 /* Open a client or server TCP network socket.
@@ -184,7 +184,7 @@ TCPsocket SDLNet_TCP_OpenClient(IPaddress *ip)
 */
 TCPsocket SDLNet_TCP_Open(IPaddress *ip)
 {
-    return _SDLNet_TCP_Open(
+    return SDLNet_TCP_OpenInternal(
         ip,
         (ip->host != INADDR_NONE) && (ip->host != INADDR_ANY)
     );

--- a/SDLnetTCP.c
+++ b/SDLnetTCP.c
@@ -36,12 +36,13 @@ struct _TCPsocket {
     int sflag;
 };
 
-/* Open a TCP network socket
-   If 'remote' is NULL, this creates a local server socket on the given port,
-   otherwise a TCP connection to the remote host and port is attempted.
+/* Open a TCP network socket.
+   If `openAsClient` is nonzero, this creates a local server socket
+   on the given port, otherwise a TCP connection to the remote host
+   and port is attempted.
    The newly created socket is returned, or NULL if there was an error.
 */
-TCPsocket SDLNet_TCP_Open(IPaddress *ip)
+static TCPsocket _SDLNet_TCP_Open(IPaddress *ip, int openAsClient)
 {
     TCPsocket sock;
     struct sockaddr_in sock_addr;
@@ -59,9 +60,8 @@ TCPsocket SDLNet_TCP_Open(IPaddress *ip)
         SDLNet_SetError("Couldn't create socket");
         goto error_return;
     }
-
-    /* Connect to remote, or bind locally, as appropriate */
-    if ( (ip->host != INADDR_NONE) && (ip->host != INADDR_ANY) ) {
+    
+    if (openAsClient) {
 
     /* #########  Connecting to remote */
         SDL_memset(&sock_addr, 0, sizeof(sock_addr));
@@ -81,7 +81,8 @@ TCPsocket SDLNet_TCP_Open(IPaddress *ip)
     /* ##########  Binding locally */
         SDL_memset(&sock_addr, 0, sizeof(sock_addr));
         sock_addr.sin_family = AF_INET;
-        sock_addr.sin_addr.s_addr = INADDR_ANY;
+        sock_addr.sin_addr.s_addr = (ip->host == INADDR_NONE) ?
+                                    INADDR_ANY : ip->host;
         sock_addr.sin_port = ip->port;
 
 /*
@@ -154,6 +155,39 @@ TCPsocket SDLNet_TCP_Open(IPaddress *ip)
 error_return:
     SDLNet_TCP_Close(sock);
     return(NULL);
+}
+
+/* Open a server TCP network socket.
+   If `ip->host` is INADDR_NONE or INADDR_ANY, the socket is bound to
+   all interfaces, otherwise it is bound to the specified interface.
+   The newly created socket is returned, or NULL if there was an error.
+*/
+TCPsocket SDLNet_TCP_OpenServer(IPaddress *ip)
+{
+    return _SDLNet_TCP_Open(ip, 0);
+}
+
+/* Open a client TCP network socket.
+   Attempt a TCP connection to the remote host and port.
+   The newly created socket is returned, or NULL if there was an error.
+*/
+TCPsocket SDLNet_TCP_OpenClient(IPaddress *ip)
+{
+    return _SDLNet_TCP_Open(ip, 1);
+}
+
+/* Open a client or server TCP network socket.
+   If `ip->host` is INADDR_NONE or INADDR_ANY, this creates a local server
+   socket on the given port, otherwise a TCP connection to the remote host
+   and port is attempted.
+   The newly created socket is returned, or NULL if there was an error.
+*/
+TCPsocket SDLNet_TCP_Open(IPaddress *ip)
+{
+    return _SDLNet_TCP_Open(
+        ip,
+        (ip->host != INADDR_NONE) && (ip->host != INADDR_ANY)
+    );
 }
 
 /* Accept an incoming connection on the given server socket.


### PR DESCRIPTION
Currently, the API only allows for a TCP server to be bound to all interfaces with INADDR_ANY. Specifying any other host in SDLNet_TCP_Open will create a client instead. A nice feature would be to allow binding to a specific interface such as localhost.

To achieve this, two functions (SDLNet_TCP_OpenServer and SDLNet_TCP_OpenClient) can be added to the API which lets us explicitly choose between a server and client while also allowing us to specify which interface the server should be bound to.
The original SDLNet_TCP_Open still exists and functions as before.