### PR TITLE
Use const IPaddress * in TCP open functions

### DIFF
--- a/SDL_net.h
+++ b/SDL_net.h
@@ -224,7 +224,7 @@ typedef struct _TCPsocket *TCPsocket;
  * \sa SDLNet_TCP_OpenClient
  * \sa SDLNet_TCP_Open
  */
-extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenServer(IPaddress *ip);
+extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenServer(const IPaddress *ip);
 
 /**
  * Open a client TCP network socket.
@@ -242,7 +242,7 @@ extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenServer(IPaddress *ip);
  * \sa SDLNet_TCP_OpenServer
  * \sa SDLNet_TCP_Open
  */
-extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenClient(IPaddress *ip);
+extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenClient(const IPaddress *ip);
 
 /**
  * Open a TCP network socket.
@@ -262,7 +262,7 @@ extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_OpenClient(IPaddress *ip);
  * \sa SDLNet_TCP_OpenServer
  * \sa SDLNet_TCP_OpenClient
  */
-extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_Open(IPaddress *ip);
+extern DECLSPEC TCPsocket SDLCALL SDLNet_TCP_Open(const IPaddress *ip);
 
 /**
  * Accept an incoming connection on the given server socket.

--- a/SDLnetTCP.c
+++ b/SDLnetTCP.c
@@ -42,7 +42,7 @@ struct _TCPsocket {
    and port is attempted.
    The newly created socket is returned, or NULL if there was an error.
 */
-static TCPsocket SDLNet_TCP_OpenInternal(IPaddress *ip, int openAsClient)
+static TCPsocket SDLNet_TCP_OpenInternal(const IPaddress *ip, int openAsClient)
 {
     TCPsocket sock;
     struct sockaddr_in sock_addr;
@@ -162,7 +162,7 @@ error_return:
    all interfaces, otherwise it is bound to the specified interface.
    The newly created socket is returned, or NULL if there was an error.
 */
-TCPsocket SDLNet_TCP_OpenServer(IPaddress *ip)
+TCPsocket SDLNet_TCP_OpenServer(const IPaddress *ip)
 {
     return SDLNet_TCP_OpenInternal(ip, 0);
 }
@@ -171,7 +171,7 @@ TCPsocket SDLNet_TCP_OpenServer(IPaddress *ip)
    Attempt a TCP connection to the remote host and port.
    The newly created socket is returned, or NULL if there was an error.
 */
-TCPsocket SDLNet_TCP_OpenClient(IPaddress *ip)
+TCPsocket SDLNet_TCP_OpenClient(const IPaddress *ip)
 {
     return SDLNet_TCP_OpenInternal(ip, 1);
 }
@@ -182,7 +182,7 @@ TCPsocket SDLNet_TCP_OpenClient(IPaddress *ip)
    and port is attempted.
    The newly created socket is returned, or NULL if there was an error.
 */
-TCPsocket SDLNet_TCP_Open(IPaddress *ip)
+TCPsocket SDLNet_TCP_Open(const IPaddress *ip)
 {
     return SDLNet_TCP_OpenInternal(
         ip,


### PR DESCRIPTION
IPaddress is not modified anywhere in SDLNet_TCP_Open* functions so we can safely change the API to use const parameters.