### PR TITLE
Add support for blocking sockets

### DIFF
--- a/examples/simple-http-get.c
+++ b/examples/simple-http-get.c
@@ -32,12 +32,14 @@ int main(int argc, char **argv)
                 SDL_Log("Out of memory!");
             } else if (!sock) {
                 SDL_Log("Failed to create stream socket to %s: %s\n", argv[i], SDL_GetError());
+            } else if (!SDLNet_SetSocketBlocking((SDLNet_GenericSocket*)sock, true)) {
+                SDL_Log("Enabling blocking mode failed!");
+            } else if (!SDLNet_SetBlockingSocketTimeout((SDLNet_GenericSocket*) sock, 2000, true)) {
+                SDL_Log("Setting receive timeout failed!");
             } else if (SDLNet_WaitUntilConnected(sock, -1) < 0) {
                 SDL_Log("Failed to connect to %s: %s", argv[i], SDL_GetError());
             } else if (!SDLNet_WriteToStreamSocket(sock, req, SDL_strlen(req))) {
                 SDL_Log("Failed to write to %s: %s", argv[i], SDL_GetError());
-            } else if (SDLNet_WaitUntilStreamSocketDrained(sock, -1) < 0) {
-                SDL_Log("Failed to finish write to %s: %s", argv[i], SDL_GetError());
             } else {
                 char buf[512];
                 int br;

--- a/include/SDL3_net/SDL_net.h
+++ b/include/SDL3_net/SDL_net.h
@@ -425,6 +425,64 @@ extern SDL_DECLSPEC SDLNet_Address **SDLCALL SDLNet_GetLocalAddresses(int *num_a
 extern SDL_DECLSPEC void SDLCALL SDLNet_FreeLocalAddresses(SDLNet_Address **addresses);
 
 
+/* Generic socket API... */
+
+typedef union SDLNet_GenericSocket SDLNet_GenericSocket;  /**< a generic socket. */
+
+typedef struct SDLNet_CommonSocket SDLNet_CommonSocket;  /**< the base socket. */
+
+/**
+ * Set a socket to blocking or non-blocking mode. At initialization, blocking
+ * is disabled.
+ *
+ * Setting a socket to blocking mode means that when you call a function that
+ * reads or writes data, it will not return until it has done its work. On the
+ * other hand, a non-blocking socket will return immediately.
+ * 
+ * Most games use non-blocking mode. If the data you are sending or receiving
+ * is critical priority, and you trust the network, it might be okay
+ * to use blocking mode. Also, if the networking is being done in a separate
+ * dedicated thread, blocking mode might be okay. It's worth noting that
+ * blocking mode is preferred to a naive busy-wait loop because it will save
+ * CPU time and delegate the job of waiting diligently to the system.
+ *
+ * \param sock The socket to set blocking mode on.
+ * \param blocking true to enable blocking mode, false to disable it.
+ * \returns true on success, false on error; call SDL_GetError() for details.
+ *
+ * \since This function is available since SDL_Net 3.0.0.
+ * 
+ * \sa SDLNet_GetSocketBlocking
+ * \sa SDLNet_SetBlockingSocketReceiveTimeout
+ * \sa SDLNet_SetBlockingSocketTimeout
+ */
+extern SDL_DECLSPEC bool SDLCALL SDLNet_SetSocketBlocking(SDLNet_GenericSocket *sock, bool blocking);
+
+/**
+ * Get the blocking mode of a socket.
+ *
+ * \param sock The socket to query.
+ * \returns true if the socket is in blocking mode, false if it is not.
+ *
+ * \since This function is available since SDL_Net 3.0.0.
+ *
+ * \sa SDLNet_SetSocketBlocking
+ */
+extern SDL_DECLSPEC bool SDLCALL SDLNet_GetSocketBlocking(SDLNet_GenericSocket *sock);
+
+/**
+ * Set the send or receive timeout for a blocking socket.
+ *
+ * \param sock The socket to set the send timeout on.
+ * \param timeout_ms The timeout in milliseconds.
+ * \param is_recv true to set the receive timeout, false to set the send timeout.
+ * \returns true on success, false on error; call SDL_GetError() for details.
+ * 
+ * \sa SDLNet_SetSocketBlocking
+ */
+extern SDL_DECLSPEC bool SDLCALL SDLNet_SetBlockingSocketTimeout(SDLNet_GenericSocket *sock, int timeout_ms, bool is_recv);
+
+
 /* Streaming (TCP) API... */
 
 typedef struct SDLNet_StreamSocket SDLNet_StreamSocket;  /**< a TCP socket. Reliable transmission, with the usual pros/cons. */

--- a/include/SDL3_net/SDL_net.h
+++ b/include/SDL3_net/SDL_net.h
@@ -453,7 +453,6 @@ typedef struct SDLNet_CommonSocket SDLNet_CommonSocket;  /**< the base socket. *
  * \since This function is available since SDL_Net 3.0.0.
  * 
  * \sa SDLNet_GetSocketBlocking
- * \sa SDLNet_SetBlockingSocketReceiveTimeout
  * \sa SDLNet_SetBlockingSocketTimeout
  */
 extern SDL_DECLSPEC bool SDLCALL SDLNet_SetSocketBlocking(SDLNet_GenericSocket *sock, bool blocking);

--- a/include/SDL3_net/SDL_net.h
+++ b/include/SDL3_net/SDL_net.h
@@ -1286,7 +1286,7 @@ extern SDL_DECLSPEC void SDLCALL SDLNet_DestroyDatagramSocket(SDLNet_DatagramSoc
  * timeout is reached, this returns zero. On error, this returns -1.
  *
  * \param vsockets an array of pointers to various objects that can be waited
- *                 on, each cast to a void pointer.
+ *                 on, each cast to union members.
  * \param numsockets the number of pointers in the `vsockets` array.
  * \param timeout Number of milliseconds to wait for new input to become
  *                available. -1 to wait indefinitely, 0 to check once without
@@ -1304,7 +1304,7 @@ extern SDL_DECLSPEC void SDLCALL SDLNet_DestroyDatagramSocket(SDLNet_DatagramSoc
  * \sa SDLNet_SendDatagram
  * \sa SDLNet_ReceiveDatagram
  */
-extern SDL_DECLSPEC int SDLCALL SDLNet_WaitUntilInputAvailable(void **vsockets, int numsockets, Sint32 timeout);
+extern SDL_DECLSPEC int SDLCALL SDLNet_WaitUntilInputAvailable(SDLNet_GenericSocket **vsockets, int numsockets, Sint32 timeout);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -1610,7 +1610,7 @@ union SDLNet_GenericSocket
     SDLNet_StreamSocket stream;
     SDLNet_DatagramSocket dgram;
     SDLNet_Server server;
-} SDLNet_GenericSocket;
+};
 
 bool SDLNet_SetSocketBlocking(SDLNet_GenericSocket *sock, bool blocking)
 {

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -1603,7 +1603,7 @@ void SDLNet_DestroyDatagramSocket(SDLNet_DatagramSocket *sock)
     }
 }
 
-typedef union SDLNet_GenericSocket
+union SDLNet_GenericSocket
 {
     SDLNet_SocketType socktype;
     SDLNet_CommonSocket common;

--- a/src/SDL_net.sym
+++ b/src/SDL_net.sym
@@ -14,6 +14,7 @@ SDL3_net_0.0.0 {
     SDLNet_GetAddressString;
     SDLNet_GetConnectionStatus;
     SDLNet_GetLocalAddresses;
+    SDLNet_GetSocketBlocking;
     SDLNet_GetStreamSocketAddress;
     SDLNet_GetStreamSocketPendingWrites;
     SDLNet_Init;
@@ -23,6 +24,8 @@ SDL3_net_0.0.0 {
     SDLNet_RefAddress;
     SDLNet_ResolveHostname;
     SDLNet_SendDatagram;
+    SDLNet_SetBlockingSocketTimeout;
+    SDLNet_SetSocketBlocking;
     SDLNet_SimulateAddressResolutionLoss;
     SDLNet_SimulateDatagramPacketLoss;
     SDLNet_SimulateStreamPacketLoss;


### PR DESCRIPTION
As I promised a while ago in Issue #113, here's support for blocking sockets modes, as well as setting OS-handled socket send/receive timeouts. This is my first time contributing to an SDL project, so I'm sorry if I do something wrong!

Functions added:
* `SDLNet_SetSocketBlocking`
* `SDLNet_GetSocketBlocking`
* `SDLNet_SetBlockingSocketTimeout`

All of these accept arguments of pointers to `SDLNet_GenericSocket`, a new union of socket types, which is also now the paramater type for `SDLNet_WaitUntilInputAvailable`

`simple-http-get.c` makes use of blocking sockets now.

PS: I haven't fully tested this code on a Unix system, only Windows, so their might be bugs there.