### PR TITLE
Reenable building on Windows 95 for SDL 1.2

### DIFF
--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -73,6 +73,10 @@ typedef int socklen_t;
 typedef Uint32 socklen_t;
 #endif
 
+#if defined(__USE_W32_SOCKETS) && !defined(socklen_t)
+typedef SOCKET socklen_t
+#endif
+
 /* System-dependent definitions */
 #ifndef __USE_W32_SOCKETS
 #ifdef __OS2__

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -74,7 +74,7 @@ typedef Uint32 socklen_t;
 #endif
 
 #if defined(__USE_W32_SOCKETS) && !defined(socklen_t)
-typedef SOCKET socklen_t;
+typedef int socklen_t;
 #endif
 
 /* System-dependent definitions */

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -74,7 +74,7 @@ typedef Uint32 socklen_t;
 #endif
 
 #if defined(__USE_W32_SOCKETS) && !defined(socklen_t)
-typedef SOCKET socklen_t
+typedef SOCKET socklen_t;
 #endif
 
 /* System-dependent definitions */

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -73,7 +73,7 @@ typedef int socklen_t;
 typedef Uint32 socklen_t;
 #endif
 
-#if defined(__USE_W32_SOCKETS) && !defined(socklen_t)
+#if defined(__USE_W32_SOCKETS) && !defined(IP_MSFILTER_SIZE)
 typedef int socklen_t;
 #endif
 

--- a/VisualC/SDL_net.dsp
+++ b/VisualC/SDL_net.dsp
@@ -69,7 +69,7 @@ LINK32=link.exe
 # PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /MTd /W3 /Gm /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
-# ADD CPP /nologo /MD /W3 /Gm /GX /ZI /Od /I "./include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
 # ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /o "NUL" /win32
 # ADD MTL /nologo /D "_DEBUG" /mktyplib203 /o "NUL" /win32
 # ADD BASE RSC /l 0x407 /d "_DEBUG"

--- a/VisualC/SDL_net.dsp
+++ b/VisualC/SDL_net.dsp
@@ -111,5 +111,9 @@ SOURCE=..\SDLnetTCP.c
 
 SOURCE=..\SDLnetUDP.c
 # End Source File
+# Begin Source File
+
+SOURCE=Version.rc
+# End Source File
 # End Target
 # End Project

--- a/VisualC/SDL_net.dsp
+++ b/VisualC/SDL_net.dsp
@@ -1,0 +1,115 @@
+# Microsoft Developer Studio Project File - Name="SDL_net" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Dynamic-Link Library" 0x0102
+
+CFG=SDL_net - Win32 Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE 
+!MESSAGE NMAKE /f "SDL_net.mak".
+!MESSAGE 
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE 
+!MESSAGE NMAKE /f "SDL_net.mak" CFG="SDL_net - Win32 Debug"
+!MESSAGE 
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "SDL_net - Win32 Release" (based on "Win32 (x86) Dynamic-Link Library")
+!MESSAGE "SDL_net - Win32 Debug" (based on "Win32 (x86) Dynamic-Link Library")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+MTL=midl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "SDL_net - Win32 Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "Release"
+# PROP BASE Intermediate_Dir "Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Release"
+# PROP Intermediate_Dir "Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MT /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /FD /c
+# ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /o "NUL" /win32
+# ADD MTL /nologo /D "NDEBUG" /mktyplib203 /o "NUL" /win32
+# ADD BASE RSC /l 0x407 /d "NDEBUG"
+# ADD RSC /l 0x407 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /machine:I386
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib wsock32.lib SDL.lib /nologo /subsystem:windows /dll /machine:I386
+
+!ELSEIF  "$(CFG)" == "SDL_net - Win32 Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "Debug"
+# PROP BASE Intermediate_Dir "Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Debug"
+# PROP Intermediate_Dir "Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MTd /W3 /Gm /GX /Zi /Od /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /Gm /GX /ZI /Od /I "./include" /D "WIN32" /D "_DEBUG" /D "_WINDOWS" /YX /FD /c
+# ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /o "NUL" /win32
+# ADD MTL /nologo /D "_DEBUG" /mktyplib203 /o "NUL" /win32
+# ADD BASE RSC /l 0x407 /d "_DEBUG"
+# ADD RSC /l 0x407 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib wsock32.lib SDL.lib iphlpapi.lib /nologo /subsystem:windows /dll /debug /machine:I386 /pdbtype:sept
+
+!ENDIF 
+
+# Begin Target
+
+# Name "SDL_net - Win32 Release"
+# Name "SDL_net - Win32 Debug"
+# Begin Source File
+
+SOURCE=..\SDL_net.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\SDLnet.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\SDLnetselect.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\SDLnetsys.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\SDLnetTCP.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\SDLnetUDP.c
+# End Source File
+# End Target
+# End Project

--- a/VisualC/SDL_net.dsw
+++ b/VisualC/SDL_net.dsw
@@ -1,0 +1,29 @@
+Microsoft Developer Studio Workspace File, Format Version 6.00
+# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
+
+###############################################################################
+
+Project: "SDL_net"=.\SDL_net.dsp - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+}}}
+
+###############################################################################
+
+Global:
+
+Package=<5>
+{{{
+}}}
+
+Package=<3>
+{{{
+}}}
+
+###############################################################################
+


### PR DESCRIPTION
Adds the former VS6 project files and defines socklen_t for the benefit of particularly old SDK versions.