### PR TITLE
PumpDatagramSocket(): return -1 on invalid socket parameter

### DIFF
--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -1357,7 +1357,8 @@ static int SendOneDatagram(SDLNet_DatagramSocket *sock, SDLNet_Address *addr, Ui
 static int PumpDatagramSocket(SDLNet_DatagramSocket *sock)
 {
     if (!sock) {
-        return SDL_InvalidParamError("sock");
+        SDL_InvalidParamError("sock");
+        return -1;
     }
 
     while (sock->pending_output_len > 0) {


### PR DESCRIPTION
returning -1
 instead of false, which is 0, which is success.