### PR TITLE
NET_WaitUntilInputAvailable(): check if caller provided negative value

### DIFF
--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -1592,6 +1592,8 @@ int NET_WaitUntilInputAvailable(void **vsockets, int numsockets, int timeoutms)
     NET_GenericSocket **sockets = (NET_GenericSocket **) vsockets;
     if (!sockets) {
         return SDL_InvalidParamError("sockets");
+    } else if (numsockets < 0) {
+        return SDL_InvalidParamError("numsockets");
     } else if (numsockets == 0) {
         return 0;
     }


### PR DESCRIPTION
I thought you might want this. I added it after getting this warning (using gcc (GCC) 14.2.1 20250207)

/home/andy/src/libsdl-org/SDL_net/src/SDL_net.c: In function ‘NET_WaitUntilInputAvailable’:
/home/andy/src/libsdl-org/SDL_net/src/SDL_net.c:1649:24: warning: ‘poll’ specified size 18446744056529682432 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
 1649 |         const int rc = poll(pfds, (nfds_t)numsockets, timeoutms);
