### PR TITLE
Add hint SDL_NET_HINT_IP_DEFAULT_VERSION to select IPv6 or IPv4

### DIFF
--- a/include/SDL3_net/SDL_net.h
+++ b/include/SDL3_net/SDL_net.h
@@ -87,6 +87,16 @@ extern "C" {
      (SDL_NET_MAJOR_VERSION > X || SDL_NET_MINOR_VERSION >= Y) && \
      (SDL_NET_MAJOR_VERSION > X || SDL_NET_MINOR_VERSION > Y || SDL_NET_MICRO_VERSION >= Z))
 
+/**
+ * A variable setting the default IP value to "IPv4" or "IPv6"
+ *
+ * This hint should be set before the first call to creating a socket 
+ * bound to a NULL address (e.g. NET_CreateServer, NET_CreateDatagramSocket)
+ * or resolving a hostname (NET_ResolveHostname).
+ *
+ * \since This hint is available since SDL_net 3.0.0
+ */
+#define SDL_NET_HINT_IP_DEFAULT_VERSION "SDL_NET_IP_DEFAULT_VERSION"
 
 /**
  * This function gets the version of the dynamically linked SDL_net library.

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -165,7 +165,7 @@ static char *CreateSocketErrorString(int rc)
         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), /* Default language */
         msgbuf,
         SDL_arraysize(msgbuf),
-        NULL 
+        NULL
     );
     if (bw == 0) {
         return SDL_strdup("Unknown error");
@@ -225,8 +225,23 @@ static NET_Status ResolveAddress(NET_Address *addr)
     struct addrinfo *ainfo = NULL;
     int rc;
 
+    struct addrinfo hints, *phints = &hints;
+    SDL_zero(hints);
+
+    const char *hint = SDL_GetHint(SDL_NET_HINT_IP_DEFAULT_VERSION);
+    if (hint) {
+        if (SDL_strcasecmp(hint, "ipv4") == 0) {
+            hints.ai_family = AF_INET;
+        } else if (SDL_strcasecmp(hint, "ipv6") == 0) {
+            hints.ai_family = AF_INET6;
+            hints.ai_flags  = AI_V4MAPPED;
+        }
+    } else {
+        phints = NULL;
+    }
+
     //SDL_Log("getaddrinfo '%s'", addr->hostname);
-    rc = getaddrinfo(addr->hostname, NULL, NULL, &ainfo);
+    rc = getaddrinfo(addr->hostname, NULL, phints, &ainfo);
     //SDL_Log("rc=%d", rc);
     if (rc != 0) {
         addr->errstr = CreateGetAddrInfoErrorString(rc);
@@ -779,6 +794,16 @@ static struct addrinfo *MakeAddrInfoWithPort(const NET_Address *addr, const int 
     hints.ai_socktype = socktype;
     //hints.ai_protocol = ainfo ? ainfo->ai_protocol : 0;
     hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV | (!ainfo ? AI_PASSIVE : 0);
+
+    const char *hint = SDL_GetHint(SDL_NET_HINT_IP_DEFAULT_VERSION);
+    if (!addr && hint) {
+        if (SDL_strcasecmp(hint, "ipv4") == 0) {
+            hints.ai_family = AF_INET;
+        } else if (SDL_strcasecmp(hint, "ipv6") == 0) {
+            hints.ai_family = AF_INET6;
+            hints.ai_flags |= AI_V4MAPPED;
+        }
+    }
 
     char service[16];
     SDL_snprintf(service, sizeof (service), "%d", (int) port);


### PR DESCRIPTION
When creating a socket bound to a NULL address, the default is AF_UNSPEC. This is causing a problem in my mixed IPv4/IPv6 environment (Window 10).  A hint will allow the user to specify what they want to use.

Also use SDL_NET_HINT_IP_DEFAULT_VERSION in ResolveAddress So that the ip addresses will be in a consistent version.

Replacing pull request #120  with this one.