### PR TITLE
Fix null dereference and iface overrun in getifaddrs path

### DIFF
--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -719,9 +719,14 @@ failed:
     }
 
     NetworkInterfaces *iface = &new_interfaces[0];
-    for (struct ifaddrs *i = ifaddr; i != NULL; i = i->ifa_next, iface++) {
+    for (struct ifaddrs *i = ifaddr; i != NULL; i = i->ifa_next) {
         if (i->ifa_name == NULL) {
-            continue;  // i guess.
+            continue;  // not counted in the first pass, no adjustment needed.
+        }
+
+        if (i->ifa_addr == NULL) {
+            new_num_interfaces--;  // was counted in the first pass, undo it.
+            continue;
         }
 
         // !!! FIXME: getifaddrs doesn't return the sockaddr length, so we have to go with known protocols.  :/
@@ -734,7 +739,6 @@ failed:
             iface->address = CreateSDLNetAddrFromSockAddr(i->ifa_addr, sizeof (struct sockaddr_in6));
         } else {
             new_num_interfaces--;
-            iface--;
             continue;
         }
 
@@ -757,6 +761,8 @@ failed:
             NET_UnrefAddress(iface->broadcast);  // just in case.
             goto failed;
         }
+
+        iface++;  // only advance when a slot was actually filled.
     }
 
 succeeded:


### PR DESCRIPTION
Here's what @claude found. Looks ok to me...

POSIX allows ifa_addr to be NULL (e.g. interfaces with no assigned address). Add an explicit NULL check and skip such entries, adjusting new_num_interfaces since they were counted in the first pass.

The loop also had iface++ in the for-header, so any continue — including the ifa_name == NULL early-out — would still advance the pointer past an unfilled slot. Since NULL-named entries were not counted in the sizing pass, this caused subsequent slot writes to go out of bounds. Fix by moving iface++ to the bottom of the loop body so it only fires when a slot is actually filled, and remove the now-unnecessary iface-- that was compensating for the old premature increment.