### PR TITLE
Add NET_CreateBroadcastAddress (fixes #97)

### DIFF
--- a/include/SDL3_net/SDL_net.h
+++ b/include/SDL3_net/SDL_net.h
@@ -580,6 +580,52 @@ extern SDL_DECLSPEC NET_Address **SDLCALL NET_GetLocalAddresses(int *num_address
  */
 extern SDL_DECLSPEC void SDLCALL NET_FreeLocalAddresses(NET_Address **addresses);
 
+/**
+ * Obtain a NET_Address usable for broadcasting on a LAN.
+ *
+ * **WARNING**: This function exists largely for compatibility with existing
+ * software. In software that doesn't have to talk to legacy programs that
+ * use broadcasting, you are encouraged to use NET_CreateMulticastAddress()
+ * instead.
+ *
+ * Broadcast packets are sent to every machine on the LAN, unconditionally.
+ * It can be used to alert everyone of the availability of a service (such as
+ * a game server) without a more formal discovery mechanism.
+ *
+ * The returned address is usable with NET_CreateDatagramSocket() to listen
+ * for broadcasts on the LAN, and with NET_SendDatagram() to send broadcast
+ * packets.
+ *
+ * The address does not need to be resolved (NET_WaitUntilResolved() will not
+ * block and NET_GetAddressStatus() will always report NET_SUCCESS) and can be
+ * used immediately.
+ *
+ * **WARNING**: Sending to a broadcast address sends to every device on the
+ * LAN, whether they want it or not. Broadcasting sparingly is safe; for
+ * example, a server announcing itself with one packet every few seconds.
+ * Once clients discover the server they should communicate directly, not
+ * continue broadcasting. For peer-to-peer games, prefer multicast once
+ * connections are established.
+ *
+ * The `iface` parameter is an interface address to use for broadcast, as
+ * different interfaces may be on different subnets. You can get a list of
+ * valid interfaces from NET_GetLocalAddresses(). Passing NULL will send on
+ * all available interfaces.
+ *
+ * \param iface the interface to use for broadcasting. May be NULL.
+ * \returns an address that can be used for broadcast transmission, or NULL on
+ *          error; call SDL_GetError() for details.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL_net 3.0.0.
+ *
+ * \sa NET_GetLocalAddresses
+ * \sa NET_CreateDatagramSocket
+ * \sa NET_SendDatagram
+ */
+extern SDL_DECLSPEC NET_Address * SDLCALL NET_CreateBroadcastAddress(NET_Address *iface);
+
 
 /* Streaming (TCP) API... */
 

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -1343,29 +1343,34 @@ void NET_FreeLocalAddresses(NET_Address **addresses)
 
 NET_Address *NET_CreateBroadcastAddress(NET_Address *interface_addr)
 {
-    if (!InterfacesReady()) {
-        SDL_SetError("Failed to initialize network interfaces");
-        return NULL;
-    }
-
     if (interface_addr != NULL) {
+        if (!InterfacesReady()) {
+            SDL_SetError("Failed to initialize network interfaces");
+            return NULL;
+        }
         SDL_LockRWLockForReading(interface_rwlock);
         NET_Address *result = NULL;
+        bool found = false;
         for (int i = 0; i < num_interfaces; i++) {
             if (NET_CompareAddresses(interfaces[i].address, interface_addr) == 0) {
-                result = NET_RefAddress(interfaces[i].broadcast);
+                found = true;
+                if (interfaces[i].broadcast) {
+                    result = NET_RefAddress(interfaces[i].broadcast);
+                }
                 break;
             }
         }
         SDL_UnlockRWLock(interface_rwlock);
         if (!result) {
-            SDL_SetError("No broadcast address found for the specified interface");
+            SDL_SetError(found ? "Interface has no broadcast address" : "Interface not found");
         }
         return result;
     }
 
-    // NULL interface: create a special token address meaning "send on all interfaces".
-    // SendDatagram detects this (ainfo==NULL, type==NET_ADDRTYPE_BROADCAST) and iterates.
+    // NULL interface: create a sentinel token meaning "send on all interfaces".
+    // NET_SendDatagram identifies this token by (type==NET_ADDRTYPE_BROADCAST && ainfo==NULL).
+    // Real broadcast addresses always have ainfo!=NULL (set by CreateSDLNetAddrFromSockAddr),
+    // so the token is unambiguously distinguishable from a concrete broadcast address.
     NET_Address *addr = (NET_Address *) SDL_calloc(1, sizeof (*addr));
     if (!addr) {
         return NULL;
@@ -2065,7 +2070,7 @@ static bool SendBroadcastToAllInterfaces(NET_DatagramSocket *sock, Uint16 port, 
     }
     SDL_free(bcasts);
 
-    return any_success ? true : SDL_SetError("No broadcast addresses available on any interface");
+    return any_success ? true : SDL_SetError("Failed to send broadcast datagram on any interface");
 }
 
 static NET_Status SendOneDatagram(NET_DatagramSocket *sock, NET_Address *addr, Uint16 port, const void *buf, int buflen)
@@ -2141,7 +2146,8 @@ bool NET_SendDatagram(NET_DatagramSocket *sock, NET_Address *addr, Uint16 port, 
         return true;  // you won the percent_loss lottery. Drop this packet as if you sent it and it never arrived.
     }
 
-    // "broadcast on all interfaces" token address: send to every interface's broadcast address, no queueing.
+    // Sentinel from NET_CreateBroadcastAddress(NULL): send to every interface's broadcast address.
+    // Real broadcast addresses always have ainfo!=NULL; this sentinel has ainfo==NULL.
     if (addr->type == NET_ADDRTYPE_BROADCAST && !addr->ainfo) {
         return SendBroadcastToAllInterfaces(sock, port, buf, buflen);
     }

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -377,6 +377,7 @@ static bool WouldBlock(const int err)
 }
 
 static NET_Address *CreateSDLNetAddrFromSockAddr(const struct sockaddr *saddr, SockLen saddrlen);
+static NET_Status SendOneDatagram(NET_DatagramSocket *sock, NET_Address *addr, Uint16 port, const void *buf, int buflen);
 
 
 
@@ -1340,6 +1341,46 @@ void NET_FreeLocalAddresses(NET_Address **addresses)
     }
 }
 
+NET_Address *NET_CreateBroadcastAddress(NET_Address *interface_addr)
+{
+    if (!InterfacesReady()) {
+        SDL_SetError("Failed to initialize network interfaces");
+        return NULL;
+    }
+
+    if (interface_addr != NULL) {
+        SDL_LockRWLockForReading(interface_rwlock);
+        NET_Address *result = NULL;
+        for (int i = 0; i < num_interfaces; i++) {
+            if (NET_CompareAddresses(interfaces[i].address, interface_addr) == 0) {
+                result = NET_RefAddress(interfaces[i].broadcast);
+                break;
+            }
+        }
+        SDL_UnlockRWLock(interface_rwlock);
+        if (!result) {
+            SDL_SetError("No broadcast address found for the specified interface");
+        }
+        return result;
+    }
+
+    // NULL interface: create a special token address meaning "send on all interfaces".
+    // SendDatagram detects this (ainfo==NULL, type==NET_ADDRTYPE_BROADCAST) and iterates.
+    NET_Address *addr = (NET_Address *) SDL_calloc(1, sizeof (*addr));
+    if (!addr) {
+        return NULL;
+    }
+    SDL_SetAtomicInt(&addr->status, (int) NET_SUCCESS);
+    addr->type = NET_ADDRTYPE_BROADCAST;
+    addr->ainfo = NULL;
+    addr->human_readable = SDL_strdup("<broadcast>");
+    if (!addr->human_readable) {
+        SDL_free(addr);
+        return NULL;
+    }
+    return NET_RefAddress(addr);
+}
+
 static struct addrinfo *MakeAddrInfoWithPort(const NET_Address *addr, const int socktype, const Uint16 port)
 {
     const struct addrinfo *ainfo = addr ? addr->ainfo : NULL;
@@ -1996,6 +2037,37 @@ failed:
     return NULL;
 }
 
+static bool SendBroadcastToAllInterfaces(NET_DatagramSocket *sock, Uint16 port, const void *buf, int buflen)
+{
+    // Snapshot broadcast addresses under the read lock so we can send without holding it.
+    SDL_LockRWLockForReading(interface_rwlock);
+    const int n = num_interfaces;
+    NET_Address **bcasts = (NET_Address **) SDL_calloc(n, sizeof (*bcasts));
+    if (bcasts) {
+        for (int i = 0; i < n; i++) {
+            bcasts[i] = interfaces[i].broadcast ? NET_RefAddress(interfaces[i].broadcast) : NULL;
+        }
+    }
+    SDL_UnlockRWLock(interface_rwlock);
+
+    if (!bcasts) {
+        return false;
+    }
+
+    bool any_success = false;
+    for (int i = 0; i < n; i++) {
+        if (bcasts[i]) {
+            if (SendOneDatagram(sock, bcasts[i], port, buf, buflen) == NET_SUCCESS) {
+                any_success = true;
+            }
+            NET_UnrefAddress(bcasts[i]);
+        }
+    }
+    SDL_free(bcasts);
+
+    return any_success ? true : SDL_SetError("No broadcast addresses available on any interface");
+}
+
 static NET_Status SendOneDatagram(NET_DatagramSocket *sock, NET_Address *addr, Uint16 port, const void *buf, int buflen)
 {
     struct addrinfo *addrwithport = MakeAddrInfoWithPort(addr, SOCK_DGRAM, port);
@@ -2067,6 +2139,11 @@ bool NET_SendDatagram(NET_DatagramSocket *sock, NET_Address *addr, Uint16 port, 
         return true;  // nothing to do.  (!!! FIXME: but strictly speaking, a UDP packet with no payload is legal.)
     } else if (ShouldSimulateLoss(sock->percent_loss)) {
         return true;  // you won the percent_loss lottery. Drop this packet as if you sent it and it never arrived.
+    }
+
+    // "broadcast on all interfaces" token address: send to every interface's broadcast address, no queueing.
+    if (addr->type == NET_ADDRTYPE_BROADCAST && !addr->ainfo) {
+        return SendBroadcastToAllInterfaces(sock, port, buf, buflen);
     }
 
     if (sock->pending_output_len == 0) {  // nothing queued? See if we can just send this without queueing.

--- a/src/SDL_net.exports
+++ b/src/SDL_net.exports
@@ -1,6 +1,7 @@
 # SDL3_net.dylib exports
 _NET_AcceptClient
 _NET_CompareAddresses
+_NET_CreateBroadcastAddress
 _NET_CreateClient
 _NET_CreateDatagramSocket
 _NET_CreateServer

--- a/src/SDL_net.sym
+++ b/src/SDL_net.sym
@@ -2,6 +2,7 @@ SDL3_net_0.0.0 {
   global:
     NET_AcceptClient;
     NET_CompareAddresses;
+    NET_CreateBroadcastAddress;
     NET_CreateClient;
     NET_CreateDatagramSocket;
     NET_CreateServer;


### PR DESCRIPTION
This is what @claude whipped up. I couldn't tell you if it was close or not. If you don't wanna review vibe-coded PRs, feel free to close without comment. ;) If I understood this stuff better, I'd review it and improve it myself...

Implement NET_CreateBroadcastAddress(NET_Address *iface):
- When iface is non-NULL, returns the broadcast address for that specific interface from the already-enumerated interfaces table.
- When iface is NULL, returns a sentinel address that causes NET_SendDatagram to iterate over all interfaces and send to each one's broadcast address.

SO_BROADCAST is already set on datagram sockets, so specific broadcast addresses work without further socket changes. The all-interfaces path snapshots the broadcast addresses under the read lock, then sends to each outside the lock.