### PR TITLE
unix: Make network monitoring optional in getifaddrs() impl

### DIFF
--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -492,6 +492,13 @@ static void RefreshInterfaces(void)  // WINDOWS VERSION
 // AF_NETLINK covers Linux (and by extension Android). PF_ROUTE covers the BSDs (and by extension Apple platforms).
 // This doesn't cover all Unix platforms that ever existed, but this hits just about everything that is still being maintained seriously.
 
+#if defined(USE_NETLINK) || defined(PF_ROUTE)
+#define USE_NETWORK_MONITOR 1
+#else
+#warning unknown network monitoring system for this platform - will not report network changes
+#endif
+
+#ifdef USE_NETWORK_MONITOR
 static SDL_Thread *interface_change_notifications_thread = NULL;
 static SDL_AtomicInt interface_change_notifications_flag;  // !!! FIXME
 
@@ -559,21 +566,28 @@ static int SDLCALL LinuxInterfaceChangeNotificationThread(void *data)
 
     return 0;
 }
+#endif
 
 static bool InitInterfaceChangeNotifications(void)  // LINUX/BSD VERSION
 {
+#ifdef USE_NETWORK_MONITOR
     interface_change_notifications_thread = SDL_CreateThread(LinuxInterfaceChangeNotificationThread, "SDLNetIfaceEnum", NULL);
     return (interface_change_notifications_thread != NULL);
+#else
+    return true;
+#endif
 }
 
 static void QuitInterfaceChangeNotifications(void)  // LINUX/BSD VERSION
 {
+#ifdef USE_NETWORK_MONITOR
     if (interface_change_notifications_thread) {
         SDL_SetAtomicInt(&interface_change_notifications_flag, 1);
         SDL_WaitThread(interface_change_notifications_thread, NULL);
         SDL_SetAtomicInt(&interface_change_notifications_flag, 0);
     }
     interface_change_notifications_thread = NULL;
+#endif
 }
 
 static void RefreshInterfaces(void)  // LINUX/BSD VERSION


### PR DESCRIPTION
While `getifaddrs()` is POSIX and its usage can be enabled on more platforms than the current set, network monitoring APIs are platform-specific.

Hence make the network monitoring optional, enabling it when either Netlink (Linux) or `PF_ROUTE` sockets (BSDs) is available. This gives to any other `getifaddrs()` platform a functional SDL_net, simply without updates to the available network interfaces after the first listing.

- [x] I confirm that I am the author of this code and release it to the SDL_net project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

