### PR TITLE
unix: Use getifaddrs() automatically when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,20 @@ else()
     add_library(${sdl3_net_target_name} src/SDL_net.c)
 endif()
 
+if(NOT (WIN32 OR SDLNET_STUB_ONLY))
+    check_c_source_compiles("
+        #include <ifaddrs.h>
+        int main(void) {
+          struct ifaddrs* ifap;
+          getifaddrs(&ifap);
+          return 0;
+        }
+        " HAVE_GETIFADDRS)
+    if(HAVE_GETIFADDRS)
+        target_compile_definitions(${sdl3_net_target_name} PRIVATE HAVE_GETIFADDRS)
+    endif()
+endif()
+
 add_library(SDL3_net::${sdl3_net_target_name} ALIAS ${sdl3_net_target_name})
 if("c_std_99" IN_LIST CMAKE_C_COMPILE_FEATURES)
     target_compile_features(${sdl3_net_target_name} PRIVATE c_std_99)

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -186,8 +186,7 @@ static int WindowsPoll(struct pollfd *fds, unsigned int nfds, int timeout)
 #include <linux/rtnetlink.h>
 #endif
 
-#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_ANDROID) || defined(SDL_PLATFORM_APPLE) || defined(SDL_PLATFORM_FREEBSD) || defined(SDL_PLATFORM_OPENBSD) || defined(SDL_PLATFORM_NETBSD)
-#define USE_GETIFADDRS 1
+#ifdef HAVE_GETIFADDRS
 #include <ifaddrs.h>
 #endif
 
@@ -487,7 +486,7 @@ static void RefreshInterfaces(void)  // WINDOWS VERSION
     SDL_free(addrs);
 }
 
-#elif defined(USE_NETLINK) || defined(USE_GETIFADDRS)
+#elif defined(USE_NETLINK) || defined(HAVE_GETIFADDRS)
 
 // AF_NETLINK covers Linux (and by extension Android). PF_ROUTE covers the BSDs (and by extension Apple platforms).
 // This doesn't cover all Unix platforms that ever existed, but this hits just about everything that is still being maintained seriously.


### PR DESCRIPTION
`getifaddrs()` is POSIX, and thus available on any POSIX platform. Thus, rather than hardcoding a list of platforms in which to use it, detect it using CMake enabling it automatically. The detection is not done where it does not make sense, i.e. on Windows (which has its own implementation), and when building SDL_net as empty stub.

The result is that any POSIX platform in addition to Linux/macOS/FreeBSD/OpenBSD/NetBSD will get at least basic network listing automatically, even if without any update to the available network interfaces after the first listing.

- [x] I confirm that I am the author of this code and release it to the SDL_net project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

