### PR TITLE
Android.mk: unconditionally enable getifaddrs()

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -18,7 +18,7 @@ LOCAL_SRC_FILES := \
 	$(subst $(LOCAL_PATH)/,,) \
 	$(wildcard $(LOCAL_PATH)/src/*.c) \
 
-LOCAL_CFLAGS =
+LOCAL_CFLAGS = -DHAVE_GETIFADDRS
 
 # Warnings we haven't fixed (yet)
 LOCAL_CFLAGS += -Wno-unused-parameter -Wno-sign-compare


### PR DESCRIPTION
Mimic the result of the CMake detection for ndk builds.

Followup of commit e096b0c33dcf1ac49f82a38db1dfea755c1b8491.

- [x] I confirm that I am the author of this code and release it to the SDL_net project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

