### PR TITLE
api: added NET_IOFromStreamSocket.

### DIFF
--- a/include/SDL3_net/SDL_net.h
+++ b/include/SDL3_net/SDL_net.h
@@ -1596,6 +1596,66 @@ extern SDL_DECLSPEC void SDLCALL NET_DestroyDatagramSocket(NET_DatagramSocket *s
  */
 extern SDL_DECLSPEC int SDLCALL NET_WaitUntilInputAvailable(void **vsockets, int numsockets, Sint32 timeout);
 
+
+/**
+ * Bridge a NET_StreamSocket to an SDL_IOStream.
+ *
+ * This will create an SDL_IOStream wrapper around a NET_StreamSocket, for
+ * passing a network connection to code that can talk to the SDL interface.
+ *
+ * The returned SDL_IOStream will report failure from SDL_SizeIO() and
+ * SDL_SeekIO() calls, as stream sockets have no specific data length and
+ * cannot seek through that data.
+ *
+ * Both SDL_ReadIO() and SDL_WriteIO() can be used on the returned stream
+ * at any time, as stream sockets are bidirectional.
+ *
+ * As NET_StreamSocket is non-blocking, reads from the SDL_IOStream will
+ * report zero if no data is currently available, and set their status to
+ * SDL_IO_STATUS_NOT_READY. However, many things that want to read from an
+ * SDL_IOStream will take any short read as EOF or failure, without checking
+ * the specific stream status. For these cases, you can request blocking
+ * behavior here by setting `blocking_reads` to true; internally, if the
+ * socket doesn't have data available but hasn't disconnected,
+ * NET_WaitUntilInputAvailable() will be used to put the caller to sleep
+ * _indefinitely_ until new data arrives or the connection drops. This can be
+ * an undesirable outcome as well; plan accordingly.
+ *
+ * When calling SDL_CloseIO() on the returned stream, the stream socket will
+ * be destroyed. If `flush_on_close` is true, any pending data will be sent
+ * before the stream is destroyed, which will block indefinitely until either
+ * all pending data is sent, or the connection fails. If false, this will
+ * destroy the stream socket immediately, throwing away any pending data that
+ * was not yet sent, avoiding blocking. One can explicitly call SDL_FlushIO()
+ * on the stream to block until all pending data has been sent, but many
+ * things that deal with SDL_IOStream will not do this, so `flush_on_close`
+ * is designed to help in this scenario.
+ *
+ * The stream socket will be destroyed when the returned SDL_IOStream is
+ * closed. If this function fails to create an SDL_IOStream (usually: out of
+ * memory), the stream is destroyed before returning, so in all cases, the
+ * caller should abandon `sock` once this function is called.
+ *
+ * A single NET_StreamSocket is not allowed to be used from two threads at
+ * once, and this is also true of SDL_IOStream, so the thread safety
+ * guarantees are the same with the returned SDL_IOStream bridge. Do not
+ * create two separate IOStreams from the same socket, as both will want
+ * to destroy the same object on close.
+ *
+ * \param sock the stream socket to bridge to an SDL_IOStream.
+ * \param blocking_reads if true, SDL_ReadIO will block if data isn't available.
+ * \param flush_on_close if true, SDL_CloseIO will block until all pending data is sent.
+ * \returns an SDL_IOStream that wraps the stream socket.
+ *
+ * \threadsafety You should not operate on the same socket from multiple
+ *               threads at the same time without supplying a serialization
+ *               mechanism. However, different threads may access different
+ *               sockets at the same time without problems.
+ *
+ * \since This function is available since SDL_net 3.0.0.
+ */
+extern SDL_DECLSPEC SDL_IOStream * SDLCALL NET_IOFromStreamSocket(NET_StreamSocket *sock, bool blocking_reads, bool flush_on_close);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/SDL_net.c
+++ b/src/SDL_net.c
@@ -2655,3 +2655,115 @@ int NET_WaitUntilInputAvailable(void **vsockets, int numsockets, int timeoutms)
 
     return retval;
 }
+
+
+// SDL_IOStream bridge ...
+
+typedef struct StreamSocketIOData
+{
+    NET_StreamSocket *sock;
+    bool blocking_reads;
+    bool flush_on_close;
+} StreamSocketIOData;
+
+static Sint64 SDLCALL streamsocketio_size(void *userdata)
+{
+    SDL_SetError("Stream sockets have no total size");
+    return -1;
+}
+
+static Sint64 SDLCALL streamsocketio_seek(void *userdata, Sint64 offset, SDL_IOWhence whence)
+{
+    SDL_SetError("Stream sockets cannot seek");
+    return -1;
+}
+
+static size_t SDLCALL streamsocketio_read(void *userdata, void *vptr, size_t size, SDL_IOStatus *status)
+{
+    Uint8 *ptr = (Uint8 *) vptr;
+    StreamSocketIOData *data = (StreamSocketIOData *) userdata;
+    NET_StreamSocket *sock = data->sock;
+    const bool blocking_reads = data->blocking_reads;
+    size_t retval = 0;
+    int remaining = (int) size;
+    while (remaining > 0) {
+        const int br = NET_ReadFromStreamSocket(sock, ptr, remaining);
+        if (br < 0) {  // uhoh, connection failed/dropped.
+            *status = SDL_IO_STATUS_EOF;  // we charitably call this "EOF" instead of "ERROR".
+            return retval;
+        } else if (br == 0) {  // no new data available.
+            if (blocking_reads) {
+                NET_WaitUntilInputAvailable((void **) &sock, 1, -1);  // sleep until something happens.
+                continue;  // try again!
+            }
+            *status = SDL_IO_STATUS_NOT_READY;
+            return retval;
+        } else {
+            SDL_assert(br <= remaining);
+            remaining -= br;
+            ptr += br;
+            retval += br;
+        }
+    }
+
+    return retval;
+}
+
+static size_t SDLCALL streamsocketio_write(void *userdata, const void *ptr, size_t size, SDL_IOStatus *status)
+{
+    StreamSocketIOData *data = (StreamSocketIOData *) userdata;
+    if (!NET_WriteToStreamSocket(data->sock, ptr, (int) size)) {
+        *status = SDL_IO_STATUS_ERROR;
+        return 0;  // some might have made it through, but we don't know.
+    }
+    return size;
+}
+
+static bool SDLCALL streamsocketio_flush(void *userdata, SDL_IOStatus *status)
+{
+    StreamSocketIOData *data = (StreamSocketIOData *) userdata;
+    return NET_WaitUntilStreamSocketDrained(data->sock, -1) == 0;
+}
+
+static bool SDLCALL streamsocketio_close(void *userdata)
+{
+    StreamSocketIOData *data = (StreamSocketIOData *) userdata;
+    const bool retval = data->flush_on_close ? (NET_WaitUntilStreamSocketDrained(data->sock, -1) == 0) : 0;
+    NET_DestroyStreamSocket(data->sock);
+    SDL_free(data);
+    return retval;
+}
+
+SDL_IOStream *NET_IOFromStreamSocket(NET_StreamSocket *sock, bool blocking_reads, bool flush_on_close)
+{
+    if (!sock) {
+        SDL_InvalidParamError("sock");
+        return NULL;
+    }
+
+    SDL_IOStreamInterface iface;
+    SDL_INIT_INTERFACE(&iface);
+    iface.size = streamsocketio_size;
+    iface.seek = streamsocketio_seek;
+    iface.read = streamsocketio_read;
+    iface.write = streamsocketio_write;
+    iface.flush = streamsocketio_flush;
+    iface.close = streamsocketio_close;
+
+    SDL_IOStream *retval = NULL;
+    StreamSocketIOData *data = (StreamSocketIOData *) SDL_calloc(1, sizeof (*data));
+    if (data) {
+        data->sock = sock;
+        data->blocking_reads = blocking_reads;
+        data->flush_on_close = flush_on_close;
+        retval = SDL_OpenIO(&iface, data);
+    }
+
+    if (!retval) {
+        NET_DestroyStreamSocket(sock);
+        SDL_free(data);
+    }
+
+    return retval;
+}
+

--- a/src/SDL_net.exports
+++ b/src/SDL_net.exports
@@ -33,4 +33,5 @@ _NET_WaitUntilResolved
 _NET_WaitUntilStreamSocketDrained
 _NET_WriteToStreamSocket
 _NET_GetAddressBytes
+_NET_IOFromStreamSocket
 # extra symbols go here (don't modify this line)

--- a/src/SDL_net.sym
+++ b/src/SDL_net.sym
@@ -34,6 +34,7 @@ SDL3_net_0.0.0 {
     NET_WaitUntilStreamSocketDrained;
     NET_WriteToStreamSocket;
     NET_GetAddressBytes;
+    NET_IOFromStreamSocket;
     # extra symbols go here (don't modify this line)
   local: *;
 };


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL_net project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Basically just generates an SDL_IOStream from a NET_StreamSocket, in case something needs to talk to code that expects that interface.

Putting this in a pull request so it lives somewhere for now, but I'm not sure I really want to add this. I'm not sure it's actually useful on a raw socket without, say, HTTP negotiation upfront (which we have a request open for elsewhere).
